### PR TITLE
:zap: advanced: TextInput에 danger, warning status 추가

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,9 +1,13 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
 import styled from "styled-components";
+import { inputStyle, descriptionStyle } from "./style";
+
+type InputStatus = "default" | "danger" | "warning";
 
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   message?: React.ReactNode;
+  status?: InputStatus;
   disabled?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -15,6 +19,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       value = "",
       name,
       label,
+      status = "default",
       disabled = false,
       width = "300px",
       onChange,
@@ -37,11 +42,16 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             value={value}
             disabled={disabled}
             width={width}
+            status={status}
             onChange={handleInput}
             {...rest}
           />
         </StyledTextInputContainer>
-        {message && <StyledDescriptionText>{message}</StyledDescriptionText>}
+        {message && (
+          <StyledDescriptionText status={status}>
+            {message}
+          </StyledDescriptionText>
+        )}
       </>
     );
   },
@@ -52,10 +62,9 @@ const StyledTextInputContainer = styled("div")`
   overflow: hidden;
 `;
 
-const StyledTextInput = styled("input")`
+const StyledTextInput = styled("input")<TextInputProps>`
   outline: none;
   width: ${({ width }) => width};
-  border: 1px solid ${({ theme }) => theme.colors.general[600]};
   padding: 12px 16px;
   border-radius: 6px;
   transition: border 0.2s ease-in-out;
@@ -79,14 +88,17 @@ const StyledTextInput = styled("input")`
       border: 1px solid ${theme.colors.primary[300]};
     }
   `}
+
+  ${({ status }) => status && inputStyle[status]}
 `;
 
-const StyledDescriptionText = styled("caption")`
+const StyledDescriptionText = styled("caption")<Pick<TextInputProps, "status">>`
   display: flex;
   align-items: center;
   margin: 6px 0 0 2px;
   ${({ theme }) => theme.typography.xs};
   color: ${({ theme }) => theme.colors.black[300]};
+  ${({ status }) => status && descriptionStyle[status]}
 `;
 
 const StyledLabelText = styled("label")`

--- a/src/components/TextInput/style.ts
+++ b/src/components/TextInput/style.ts
@@ -1,0 +1,25 @@
+import { css } from "styled-components";
+
+export const inputStyle = {
+  default: css`
+    border: 1px solid ${({ theme }) => theme.colors.general[300]};
+  `,
+  danger: css`
+    border: 1px solid ${({ theme }) => theme.colors.danger[600]};
+  `,
+  warning: css`
+    border: 1px solid ${({ theme }) => theme.colors.warning[500]};
+  `,
+};
+
+export const descriptionStyle = {
+  default: css`
+    color: ${({ theme }) => theme.colors.text.secondary};
+  `,
+  danger: css`
+    color: ${({ theme }) => theme.colors.danger[600]};
+  `,
+  warning: css`
+    color: ${({ theme }) => theme.colors.warning[500]};
+  `,
+};


### PR DESCRIPTION
## 설명

- TextInput status prop 추가

## 작업내용

- danger, warning status를 추가했습니다.
- 피그마에서 스타일이 살짝 변경된 부분을 수정했습니다. (default border 색상)

## 스크린샷 (Optional)

- ![2022-10-08 23 56 58](https://user-images.githubusercontent.com/66931791/194713742-10256464-0e7f-4934-9b5e-151ff19a1508.gif)