### PR TITLE
💄style: chip 컴포넌트에 icon컴포넌트 추가, 스타일추가

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,7 +1,12 @@
 import React, { ReactNode } from "react";
 import styled from "styled-components";
-import { getBackgroundColor, getBorderColor, getColor } from "./style";
-import { CancelIcon } from "../../Icon/svg";
+import {
+  getBackgroundColor,
+  getBorderColor,
+  getCancelIconColor,
+  getColor,
+} from "./style";
+import { Icon } from "components/Icon";
 
 export type Color = "basic" | "active" | "danger" | "warning";
 type Variants = "pill" | "rounded";
@@ -43,9 +48,9 @@ const Chip = ({
       {adornments && <StyledChipAdornments>{adornments}</StyledChipAdornments>}
       <StyledChipLabel {...props}>{label}</StyledChipLabel>
       {onDelete && (
-        <CancelIconBtn value={label} onClick={handleDelete}>
-          <StyledCancelIcon aria-hidden {...props} />
-        </CancelIconBtn>
+        <StyledCancelIconContainer onClick={handleDelete}>
+          <StyledCancelIcon name="cancel" size={12} {...props} />
+        </StyledCancelIconContainer>
       )}
     </StyledChip>
   );
@@ -89,20 +94,14 @@ const StyledChipAdornments = styled.span`
   align-items: center;
 `;
 
-const StyledCancelIcon = styled(CancelIcon)<ChipProps>`
-  cursor: pointer;
-
-  height: 100%;
-  display: flex;
-  align-items: center;
-
-  & path {
-    stroke: ${({ color, outlined }) => getColor(color, outlined)};
-  }
-`;
-
-const CancelIconBtn = styled.button`
+const StyledCancelIconContainer = styled.div`
   border: none;
   padding: 0;
   background: none;
+  display: flex;
+  align-items: center;
+`;
+
+const StyledCancelIcon = styled(Icon)<ChipProps>`
+  color: ${({ color, outlined }) => getCancelIconColor(color, outlined)};
 `;

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -100,6 +100,7 @@ const StyledCancelIconContainer = styled.div`
   background: none;
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 const StyledCancelIcon = styled(Icon)<ChipProps>`

--- a/src/components/Chip/style.ts
+++ b/src/components/Chip/style.ts
@@ -40,3 +40,27 @@ export const getBackgroundColor = (color: Color, outlined?: boolean) => {
   }
   return getOutLineColor(color);
 };
+
+export const getCancelIconColor = (color: Color, outlined?: boolean) => {
+  if (outlined) {
+    switch (color) {
+      case "active":
+        return Theme.colors.primary["500"];
+      case "danger":
+        return Theme.colors.danger["500"];
+      case "warning":
+        return Theme.colors.warning["500"];
+      default:
+        return Theme.colors.general["600"];
+    }
+  } else {
+    switch (color) {
+      case "active":
+      case "danger":
+      case "warning":
+        return "#fff";
+      default:
+        return Theme.colors.general["600"];
+    }
+  }
+};

--- a/src/components/Icon/iconList.tsx
+++ b/src/components/Icon/iconList.tsx
@@ -60,7 +60,7 @@ const iconList = {
       strokeLinejoin="round"
     />
   ),
-  cancleWithCircle: (
+  cancelWithCircle: (
     <path
       fillRule="evenodd"
       clipRule="evenodd"


### PR DESCRIPTION
## 설명

- chip 컴포넌트에 icon 컴포넌트 추가

## 작업내용

- chip 컴포넌트에 icon 컴포넌트 추가
- icon 컴포넌트 스타일 추가
- iconList 오타 수정

## 스크린샷 (Optional)

<img width="108" alt="image" src="https://user-images.githubusercontent.com/66931791/195990780-530be285-7dd2-4c14-a75f-6d7eae45c031.png">
