### PR TITLE
:lipstick: style: input, button style 수정

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color?: Color;
   variants?: Variants;
   disabled?: boolean;
+  width?: string;
   onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -16,6 +17,7 @@ export const Button = ({
   variants = "filled",
   disabled = false,
   onClick,
+  width,
   children,
   ...rest
 }: ButtonProps) => {
@@ -25,6 +27,7 @@ export const Button = ({
       variants={variants}
       disabled={disabled}
       onClick={onClick}
+      width={width}
       {...rest}
     >
       {children}
@@ -37,7 +40,7 @@ const StyledButton = styled.button<ButtonProps>`
   align-items: center;
   justify-content: center;
   position: relative;
-  min-width: 70px;
+  width: ${({ width }) => width};
   height: 40px;
   padding: 8px 16px;
   border-radius: 6px;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -32,7 +32,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     };
 
     return (
-      <>
+      <Container {...rest}>
         {label && <StyledLabelText htmlFor={name}>{label}</StyledLabelText>}
         <StyledTextInputContainer>
           <StyledTextInput
@@ -44,7 +44,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             width={width}
             status={status}
             onChange={handleInput}
-            {...rest}
           />
         </StyledTextInputContainer>
         {message && (
@@ -52,10 +51,12 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             {message}
           </StyledDescriptionText>
         )}
-      </>
+      </Container>
     );
   },
 );
+
+const Container = styled("div")``;
 
 const StyledTextInputContainer = styled("div")`
   display: flex;
@@ -92,7 +93,7 @@ const StyledTextInput = styled("input")<TextInputProps>`
   ${({ status }) => status && inputStyle[status]}
 `;
 
-const StyledDescriptionText = styled("caption")<Pick<TextInputProps, "status">>`
+const StyledDescriptionText = styled("span")<Pick<TextInputProps, "status">>`
   display: flex;
   align-items: center;
   margin: 6px 0 0 2px;
@@ -106,5 +107,5 @@ const StyledLabelText = styled("label")`
   align-items: center;
   margin: 0 0 6px 2px;
   color: ${({ theme }) => theme.colors.black[400]};
-  ${({ theme }) => theme.typography.sm};
+  ${({ theme }) => theme.typography.header4};
 `;


### PR DESCRIPTION
## 설명

- input style 수정
- button에 `width` prop 추가

## 작업내용

- margin을 가장 바깥 container에서 받도록 수정
- input label style 수정
- caption -> span으로 수정 (console error)
- button에 width prop을 추가해 사용하는 곳에서 width를 지정할 수 있도록 수정

## 스크린샷 (Optional)

<img width="476" alt="image" src="https://user-images.githubusercontent.com/66931791/196100762-8b915256-6368-4f5c-a12b-c07c7dfe21ea.png">
