### PR TITLE
style: Tooltip z-index 추가

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -67,6 +67,7 @@ const TooltipContent = styled.div<TooltipContentProps>`
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  z-index: 1000;
 
   opacity: 0;
   visibility: hidden;


### PR DESCRIPTION
## 설명

- Tooltip content에 z-index 스타일 추가

## 작업내용

- Tooltip content에 `z-index` 스타일이 없어서 겹치는 오류가 생겨서 `z-index: 1000`을 추가했습니다.

<!-- ## 참고사항 (Optional)

- 그 외 참고사항을 적어주세요. -->

<!-- ## 스크린샷 (Optional)

- UI가 변경되었다면 사진이나 Gif를 추가해주세요. -->

<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
