### PR TITLE
💄style: select border->outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jci-moyeo-design-system",
-  "version": "0.1.19",
+  "version": "0.2.1",
   "keywords": [
     "component",
     "design",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -221,20 +221,22 @@ export const Select = <Multiple extends boolean = false>({
   );
 
   return (
-    <StyledContainer>
+    <>
       {label && <StyledLabelText>{label}</StyledLabelText>}
-      <Popover
-        isOpen={isOpen}
-        anchorPosition={{
-          x: 0,
-          y: 4,
-        }}
-        onClose={closeOptionDrawer}
-        opener={select}
-      >
-        {optionDrawer}
-      </Popover>
-    </StyledContainer>
+      <PopoverContainer>
+        <Popover
+          isOpen={isOpen}
+          anchorPosition={{
+            x: 0,
+            y: 4,
+          }}
+          onClose={closeOptionDrawer}
+          opener={select}
+        >
+          {optionDrawer}
+        </Popover>
+      </PopoverContainer>
+    </>
   );
 };
 
@@ -243,7 +245,9 @@ const StyledLabelText = styled("label")`
   color: ${({ theme }) => theme.colors.text.primary};
 `;
 
-const StyledContainer = styled("div")``;
+const PopoverContainer = styled("div")`
+  margin-top: 4px;
+`;
 
 const StyledInputContainer = styled("div")<{
   active: boolean;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -259,7 +259,7 @@ const StyledInputContainer = styled("div")<{
   align-items: center;
   position: relative;
   width: ${({ width }) => width};
-  min-height: 20px;
+  min-height: 22px;
   padding: 12px;
   outline: 1px solid ${({ theme }) => theme.colors.general[300]};
   border-radius: 4px;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -255,13 +255,13 @@ const StyledInputContainer = styled("div")<{
   align-items: center;
   position: relative;
   width: ${({ width }) => width};
-  min-height: 22px;
+  min-height: 20px;
   padding: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.general[300]};
+  outline: 1px solid ${({ theme }) => theme.colors.general[300]};
   border-radius: 4px;
   cursor: pointer;
   background-color: ${({ theme }) => theme.colors.general.white};
-  transition: border-color 0.2s ease-in-out;
+  transition: outline-color 0.2s ease-in-out;
 
   ${({ theme, disabled }) =>
     disabled &&
@@ -273,7 +273,7 @@ const StyledInputContainer = styled("div")<{
   ${({ theme, active }) =>
     active &&
     css`
-      border: 1px solid ${theme.colors.primary[600]};
+      outline: 1px solid ${theme.colors.primary[600]};
     `}
 
   ${({ hasValue, placeholder }) =>
@@ -289,7 +289,7 @@ const StyledInputContainer = styled("div")<{
     `};
 
   &:hover {
-    border: 1px solid ${({ theme }) => theme.colors.primary[300]};
+    outline: 1px solid ${({ theme }) => theme.colors.primary[300]};
   }
 `;
 


### PR DESCRIPTION
## 설명

- border -> outline으로 변경
- label에 margin 추가

## 작업내용

- border 때문에 height가 2px 커짐. -> outline으로 수정
- label과 popover component간의 margin 추가


## 스크린샷 (Optional)

### as-is
<img width="434" alt="image" src="https://user-images.githubusercontent.com/66931791/197101986-28e5268e-0291-44be-ba6e-6ded0ef9a6be.png">

### to-be
<img width="436" alt="image" src="https://user-images.githubusercontent.com/66931791/197102018-42f802e5-e78b-4a87-8ddd-99904a6b83e7.png">