### PR TITLE
💄style: button에 icon 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jci-moyeo-design-system",
-  "version": "0.1.19",
+  "version": "0.2.1",
   "keywords": [
     "component",
     "design",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,14 +1,17 @@
 import React, { ButtonHTMLAttributes } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import buttonStyles from "./style";
 
 type Color = "primary" | "general" | "success" | "warning" | "danger";
 type Variants = "filled" | "outlined" | "text";
+type IconPosition = "start" | "end";
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color?: Color;
   variants?: Variants;
   disabled?: boolean;
   width?: string;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
   onClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -18,6 +21,8 @@ export const Button = ({
   disabled = false,
   onClick,
   width,
+  startIcon,
+  endIcon,
   children,
   ...rest
 }: ButtonProps) => {
@@ -30,7 +35,25 @@ export const Button = ({
       width={width}
       {...rest}
     >
+      {startIcon && (
+        <IconContainer position="start">
+          {React.isValidElement(startIcon) &&
+            React.cloneElement(startIcon, {
+              ...startIcon.props,
+              color: startIcon.props.color ?? color,
+            })}
+        </IconContainer>
+      )}
       {children}
+      {endIcon && (
+        <IconContainer position="end">
+          {React.isValidElement(endIcon) &&
+            React.cloneElement(endIcon, {
+              ...endIcon.props,
+              color: endIcon.props.color ?? color,
+            })}
+        </IconContainer>
+      )}
     </StyledButton>
   );
 };
@@ -48,6 +71,7 @@ const StyledButton = styled.button<ButtonProps>`
   border: none;
   cursor: pointer;
   transition: all 0.3s ease-in-out;
+  ${({ onClick }) => !onClick && `pointer-events: none`};
   ${({ theme }) => theme.typography.md};
   ${({ color }) => color && buttonStyles.colors[color]};
   ${({ variants }) => variants && buttonStyles.variants[variants]};
@@ -58,4 +82,22 @@ const StyledButton = styled.button<ButtonProps>`
     background-color: ${({ theme }) => theme.colors.general[200]};
     color: ${({ theme }) => theme.colors.text.third};
   }
+`;
+
+const IconContainer = styled("div")<{ position: IconPosition }>`
+  padding-top: 3px;
+  ${({ position }) => {
+    switch (position) {
+      case "start": {
+        return css`
+          margin-right: 4px;
+        `;
+      }
+      case "end": {
+        return css`
+          margin-left: 4px;
+        `;
+      }
+    }
+  }}
 `;

--- a/src/stories/components/Button/Button.stories.tsx
+++ b/src/stories/components/Button/Button.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 import { Button, ButtonProps } from "components/Button";
+import { Icon } from "components/Icon";
+import styled from "styled-components";
+import { Theme } from "styles/theme";
 
 export default {
   title: "Components/Button",
@@ -12,3 +15,29 @@ const Template: Story<ButtonProps> = (args) => <Button {...args}>버튼</Button>
 export const Default: Story<ButtonProps> = (args) => <Template {...args} />;
 
 Default.args = {};
+
+export const WithIcon = () => {
+  return (
+    <Container>
+      <Button endIcon={<Icon name="write" size={24} />}>
+        모집 글 작성하기
+      </Button>
+      <StyledButton color="general">
+        <Icon name="checkWithCircle" color={Theme.colors.general[600]} />
+      </StyledButton>
+      <Button startIcon={<Icon name="write" />}>모집 글 작성하기</Button>
+    </Container>
+  );
+};
+
+const Container = styled("div")`
+  display: flex;
+
+  button {
+    margin-right: 4px;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  padding: 8px;
+`;

--- a/src/stories/components/Button/Button.stories.tsx
+++ b/src/stories/components/Button/Button.stories.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { Button, ButtonProps } from "components/Button";
 import { Icon } from "components/Icon";
 import styled from "styled-components";
-import { Theme } from "styles/theme";
 
 export default {
   title: "Components/Button",
@@ -22,9 +21,6 @@ export const WithIcon = () => {
       <Button endIcon={<Icon name="write" size={24} />}>
         모집 글 작성하기
       </Button>
-      <StyledButton color="general">
-        <Icon name="checkWithCircle" color={Theme.colors.general[600]} />
-      </StyledButton>
       <Button startIcon={<Icon name="write" />}>모집 글 작성하기</Button>
     </Container>
   );
@@ -36,8 +32,4 @@ const Container = styled("div")`
   button {
     margin-right: 4px;
   }
-`;
-
-const StyledButton = styled(Button)`
-  padding: 8px;
 `;

--- a/src/stories/components/Button/Button.stories.tsx
+++ b/src/stories/components/Button/Button.stories.tsx
@@ -18,10 +18,8 @@ Default.args = {};
 export const WithIcon = () => {
   return (
     <Container>
-      <Button endIcon={<Icon name="write" size={24} />}>
-        모집 글 작성하기
-      </Button>
       <Button startIcon={<Icon name="write" />}>모집 글 작성하기</Button>
+      <Button endIcon={<Icon name="write" />}>모집 글 작성하기</Button>
     </Container>
   );
 };


### PR DESCRIPTION
## 설명

- button에 `startIcon`, `endIcon` 추가
- onClick이 없을때 `pointer-events: none` 처리

## 작업내용

- icon에 color를 지정하면 지정한 컬러로, 지정하지 않으면 button의 color에 따르도록 했습니다.
- onClick이 지정되지 않았을때 hover, active css를 none처리했습니다.

 ## 스크린샷 (Optional)
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/66931791/197121981-f75ccdde-7f32-4551-b8cc-3dea298d7fa2.png">
