### PR TITLE
fix: Select 컴포넌트 넓이 오류 수정

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 import { Option, OptionProps } from "./Option";
-import { TextInput, TextInputProps } from "../TextInput";
+import { TextInputProps } from "../TextInput";
 import { Popover } from "../Popover";
 import { isSameComponent, useResizeEffect } from "../../utils";
 import { Icon } from "../Icon";
@@ -287,7 +287,6 @@ const StyledInputContainer = styled("div")<{
       &:before {
         content: attr(placeholder);
         white-space: nowrap;
-        width: 100%;
         color: ${({ theme }) => theme.colors.text.secondary};
       }
     `};
@@ -297,11 +296,11 @@ const StyledInputContainer = styled("div")<{
   }
 `;
 
-const TextInputOverride = styled(TextInput)`
+const TextInputOverride = styled("input")`
   ${({ theme }) => theme.typography.header4};
   border: none;
   padding: 0px;
-  width: 100vw;
+  flex: 1 1 0;
 
   &:hover,
   &:focus,


### PR DESCRIPTION
## 설명
- Select 컴포넌트 사용시 `display: grid` 안에서 사용하는 경우 넓이가 화면을 벗어나는 오류를 수정합니다.

## 작업내용
- Select 컴포넌트 수정

## 참고사항 (Optional)
- `TextInputOverride`가 `width: 100vw`로 설정되어 있어서 화면을 벗어나는 현상이 있어서 `StyledInputContainer` 안에서 전체를 차지하게 수정하였습니다. (스크린샷 참고)
-  `TextInputOverride`가 `TextInput` 컴포넌트를 사용하니 기본 넓이가 300px로 설정되는 문제가 있어서 기본 input으로 변경하였습니다.


## 스크린샷 (Optional)
### 문제 상황
![screencapture-localhost-3000-post-1-2022-10-22-09_45_33](https://user-images.githubusercontent.com/12439567/197315227-62d33a75-f5a0-47f6-88ea-ab7c5da20f32.png)

### as is
<img width="1150" alt="스크린샷 2022-10-22 오전 9 43 26" src="https://user-images.githubusercontent.com/12439567/197315133-0494b4a5-f941-4b10-801c-5f0fbf6369bc.png">

### to be
<img width="1034" alt="스크린샷 2022-10-22 오전 9 43 52" src="https://user-images.githubusercontent.com/12439567/197315138-c8d6bfd4-0658-42d1-b697-e6197316e6a9.png">

### 동작 화면
![Select](https://user-images.githubusercontent.com/12439567/197315288-d7153a0e-9187-45fe-9990-72bfc102b106.gif)



<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
