### PR TITLE
fix: Select 컴포넌트 오류 수정

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -298,6 +298,7 @@ const StyledInputContainer = styled("div")<{
 
 const TextInputOverride = styled("input")`
   ${({ theme }) => theme.typography.header4};
+  width: 0;
   border: none;
   padding: 0px;
   flex: 1 1 0;


### PR DESCRIPTION
## 설명
- Select 컴포넌트 안에 있는 input이 범위를 벗어나는 오류를 수정합니다.

## 작업내용
- Input `width: 0` 처리

## 참고사항 (Optional)
- 다음과 같이 크기가 줄어들 때 input 엘리먼트의 기본 넓이가 설정되어 
Select 컴포넌트의 범위를 벗어나게 됩니다. (검은색 부분이 input 엘리먼트입니다.)
<img width="246" alt="스크린샷 2022-10-25 오후 11 51 43" src="https://user-images.githubusercontent.com/12439567/197807745-8fefe849-815c-4ea5-bee0-4c23e3bbae2e.png">


<!-- ## 스크린샷 (Optional)

- UI가 변경되었다면 사진이나 Gif를 추가해주세요. -->

<!-- ## 링크 (Optional)

- 작업을 하면서 자신이 도움을 받았거나 리뷰어들이 PR에 대해 더욱 쉽게 이해를 할 수 있도록 링크를 추가해주세요. -->
